### PR TITLE
[build] Update to Opam 2

### DIFF
--- a/opam
+++ b/opam
@@ -1,18 +1,25 @@
-opam-version: "1.2"
+opam-version: "2.0"
 name: "sukerujo"
-version: "devel"
+version: "2.6.0"
 maintainer: "dedukti-dev@inria.fr"
 author: "Raphaël Cauderlier"
 homepage: "http://deducteam.gforge.inria.fr/sukerujo"
 bug-reports: "https://github.com/Deducteam/Dedukti/issues"
-dev-repo: "https://github.com/Deducteam/Dedukti/tree/sukerujo"
 build: [make]
 install: [make "install"]
 remove: [make "uninstall"]
-available: [ ocaml-version >= "4.02" ]
+synopsis: "An alternative Dedukti parser"
+description: "Sukerujo is an alternative parser for Dedukti bringing the following enhancements:
+ - literals for natural numbers in decimal notation
+ - literals for characters
+ - literals for strings
+ - literals for polymorphic lists
+ - local (let) definitions
+ - recursive records"
 depends: [
   "menhir"
   "ocamlbuild" {build}
   "ocamlfind" {build}
-  "dedukti" {= devel}
+  "dedukti" {= version}
+  "ocaml" {>= "4.02"}
 ]


### PR DESCRIPTION
This updates and fixes the Opam file of Sukerujo and allows to install with `opam install .`.